### PR TITLE
more specific servicemonitor selector

### DIFF
--- a/charts/krakend-operator/templates/controller-manager-metrics-monitor.yaml
+++ b/charts/krakend-operator/templates/controller-manager-metrics-monitor.yaml
@@ -19,3 +19,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      {{- include "krakend-operator.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Existing selector matches other services resulting in prometheus scrape errors